### PR TITLE
time_average_dt: add fill_na param; default FALSE (no gap-fill)

### DIFF
--- a/R/add_era5.R
+++ b/R/add_era5.R
@@ -114,7 +114,8 @@ add_era5 <- function(
       wd_name = mm$dt_meta[type == "wind direction", name_dt],
       ws_name = mm$dt_meta[type == "wind speed" | type == "windspeed", name_dt],
       report_end_interval = report_end_interval,
-      extra_rows = extra_rows
+      extra_rows = extra_rows,
+      fill_na = TRUE
     )
   }
   # Normalise both timestamp vectors to integer seconds in UTC so the equi-join

--- a/R/time_average.R
+++ b/R/time_average.R
@@ -106,7 +106,8 @@ time_average <- function(
       wd_name = wd_name,
       ws_name = ws_name,
       report_end_interval = report_end_interval,
-      extra_rows = extra_rows
+      extra_rows = extra_rows,
+      fill_na = TRUE  # ERA5 is hourly; fill sub-hourly gaps by carrying forward
     )
   }
 

--- a/R/time_average.R
+++ b/R/time_average.R
@@ -107,7 +107,7 @@ time_average <- function(
       ws_name = ws_name,
       report_end_interval = report_end_interval,
       extra_rows = extra_rows,
-      fill_na = TRUE  # ERA5 is hourly; fill sub-hourly gaps by carrying forward
+      fill_na = TRUE # ERA5 is hourly; fill sub-hourly gaps by carrying forward
     )
   }
 

--- a/R/time_average_dt.R
+++ b/R/time_average_dt.R
@@ -144,6 +144,24 @@ time_average_dt <- function(
     data.table::setnafill(dt_num, type = "nocb")
     data.table::setnafill(dt_num, type = "locf")
   }
+
+  # Remove all-NA rows at the leading/trailing edges. These arise when the
+  # padding window (extra_rows) extends the averaging range beyond the data
+  # and the report_end_interval shift moves an empty padding bin to exactly
+  # first_date, causing it to pass the trim. Interior NAs (genuine gaps)
+  # are kept because they are bounded by non-NA rows on both sides.
+  if (nrow(dt_num) > 0L) {
+    v_has_obs <- rowSums(!is.na(dt_num)) > 0L
+    if (any(v_has_obs)) {
+      i_first <- which(v_has_obs)[1L]
+      i_last <- max(which(v_has_obs))
+      if (i_first > 1L || i_last < nrow(dt_num)) {
+        dt_num <- dt_num[i_first:i_last]
+        dt <- dt[i_first:i_last]
+      }
+    }
+  }
+
   dt <- cbind(dt[, c("date", "site")], dt_num)
 
   # restore original time name

--- a/R/time_average_dt.R
+++ b/R/time_average_dt.R
@@ -57,7 +57,8 @@ time_average_dt <- function(
   wd_name = NULL,
   ws_name = NULL,
   report_end_interval = TRUE,
-  extra_rows = 2
+  extra_rows = 2,
+  fill_na = FALSE
 ) {
   # we need to make a copy to avoid modifying the original object by reference
   # i.e. we (probably) want to retain the unaveraged mm object
@@ -137,9 +138,12 @@ time_average_dt <- function(
     )
   }
 
-  # first few rows may be missing data; fill in with nocb
-  data.table::setnafill(dt_num, type = "nocb")
-  data.table::setnafill(dt_num, type = "locf")
+  # fill_na=TRUE carries ERA5 hourly values forward/backward into sub-hourly
+  # intervals; never set for observation data (would mask real data gaps).
+  if (fill_na) {
+    data.table::setnafill(dt_num, type = "nocb")
+    data.table::setnafill(dt_num, type = "locf")
+  }
   dt <- cbind(dt[, c("date", "site")], dt_num)
 
   # restore original time name


### PR DESCRIPTION
The previous unconditional setnafill(nocb/locf) was filling ALL NA values in the averaged output, including genuine long data gaps (e.g. a sensor offline for years), silently replacing them with the last known value and producing flat lines in plots.

Add fill_na parameter (default FALSE). Observation data (dt) and QC codes (dt_qc) keep fill_na=FALSE so real gaps remain NA. ERA5 reference data (dt_ref) uses fill_na=TRUE because ERA5 is hourly and must be carried forward into sub-hourly averaging intervals.