### PR TITLE
read_ceda_csv: sanitise column names with make.names()

### DIFF
--- a/R/read_ceda_csv.R
+++ b/R/read_ceda_csv.R
@@ -109,7 +109,7 @@ read_ceda_csv <- function(fname, drop_flags = TRUE) {
   )
 
   v_col_names[[1L]] <- "TIMESTAMP"
-  v_col_names <- make.unique(v_col_names, sep = ".")
+  v_col_names <- make.names(v_col_names, unique = TRUE)
 
   # ---- Read data -----------------------------------------------------------
   dt <- data.table::fread(


### PR DESCRIPTION
Replace make.unique() with make.names(unique=TRUE) so that CEDA short_name values containing spaces or brackets (e.g. "Wind Dir", "Soil Heat Flux", "WindSpd (measured)") become valid R identifiers before reaching metamet() / restrict(). Without this, those columns were silently dropped because they could not match any name_dt entry in dt_meta.