### PR TITLE
Fix: Remove local=TRUE from module sourcing to make functions globall…

### DIFF
--- a/R/run_shiny.R
+++ b/R/run_shiny.R
@@ -10,6 +10,7 @@ run_shiny <- function() {
       "shiny",
       "shinydashboard",
       "shinyjs",
+      "shinyBS",
       "shinyFiles",
       "shinyvalidate",
       "shinycssloaders",

--- a/inst/shinyApp/metqc_app/app.R
+++ b/inst/shinyApp/metqc_app/app.R
@@ -8,8 +8,14 @@ library(shinycssloaders)
 library(ggiraph)
 
 # Source module files using absolute paths
-source(system.file("shinyApp/metqc_app/mod_metadata_maker.R", package = "metamet"))
-source(system.file("shinyApp/metqc_app/mod_machine_faults.R", package = "metamet"))
+source(system.file(
+  "shinyApp/metqc_app/mod_metadata_maker.R",
+  package = "metamet"
+))
+source(system.file(
+  "shinyApp/metqc_app/mod_machine_faults.R",
+  package = "metamet"
+))
 
 # Set the gap-filling methods and codes----
 gf_choices <- setNames(df_method$method, df_method$method_longname)

--- a/inst/shinyApp/metqc_app/app.R
+++ b/inst/shinyApp/metqc_app/app.R
@@ -7,8 +7,9 @@ library(shinyFiles)
 library(shinycssloaders)
 library(ggiraph)
 
-source("mod_metadata_maker.R", local = TRUE)
-source("mod_machine_faults.R", local = TRUE)
+# Source module files using absolute paths
+source(system.file("shinyApp/metqc_app/mod_metadata_maker.R", package = "metamet"))
+source(system.file("shinyApp/metqc_app/mod_machine_faults.R", package = "metamet"))
 
 # Set the gap-filling methods and codes----
 gf_choices <- setNames(df_method$method, df_method$method_longname)
@@ -47,11 +48,6 @@ ui <- dashboardPage(
       ),
       menuItem(
         "Save Processed Data",
-        tabName = "download",
-        icon = icon('download')
-      ),
-      menuItem(
-        "Download processed data",
         tabName = "download",
         icon = icon('download')
       ),


### PR DESCRIPTION
- Removed local=TRUE parameter from source() calls in app.R
- This ensures mod_metadata_maker_ui() and mod_machine_faults_ui() are available in the global environment when the app launches
- Fixes 'could not find function' error on app startup
- also removed the download tab
- also added shinyBS dependency